### PR TITLE
Automatically close old pull requests

### DIFF
--- a/ci-droid-tasks-consumer-autoconfigure/src/main/resources/application.yml
+++ b/ci-droid-tasks-consumer-autoconfigure/src/main/resources/application.yml
@@ -64,6 +64,8 @@ ciDroidBehavior:
 #  whenPushOnDefaultBranch:
   tryToRebaseOpenPrs.enabled: true
   notifyOwnerForNonMergeablePr.enabled: true
+  closeOldPullRequests.enabled: true
+  closeOldPullRequests.limitInDays: 180
 #  whenPullRequestEvent:
   bestPracticeNotifier.enabled: true
   patternToResourceMapping:

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -107,6 +107,14 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-client-java</artifactId>
+        </dependency>
 
     </dependencies>
 </project>

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -75,6 +75,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.netflix.feign</groupId>
+            <artifactId>feign-httpclient</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-jackson</artifactId>
         </dependency>

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
@@ -20,14 +20,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static feign.FeignException.errorStatus;
 
 @FeignClient(name = "github", url = "${gitHub.api.url}", decode404 = true, configuration = RemoteGitHubConfig.class)
 public interface FeignRemoteGitHub extends RemoteGitHub {
-
 
     @RequestMapping(method = RequestMethod.GET,
             value = "/repos/{repoFullName}/pulls?status=open",
@@ -101,7 +102,6 @@ public interface FeignRemoteGitHub extends RemoteGitHub {
 
     }
 
-
     @RequestMapping(method = RequestMethod.GET,
             value = "/repos/{repoFullName}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -126,7 +126,6 @@ public interface FeignRemoteGitHub extends RemoteGitHub {
         return gitReferenceClient.createBranch(new InputRef("refs/heads/" + branchName, fromReferenceSha1));
     }
 
-
     @Override
     default User fetchCurrentUser(String oAuthToken){
 
@@ -146,6 +145,22 @@ public interface FeignRemoteGitHub extends RemoteGitHub {
 
         return gitReferenceClient.createPullRequest(newPr);
     }
+
+    @Override
+    default void closePullRequest(String repoFullName, int prNumber) {
+        HashMap<String, String> body = new HashMap<>();
+        body.put("state", "closed");
+
+        updatePullRequest(repoFullName, prNumber, body);
+    }
+
+    @RequestMapping(method = RequestMethod.PATCH,
+            value = "/repos/{repoFullName}/pulls/{prNumber}",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    void updatePullRequest(@PathVariable("repoFullName") String repoFullName,
+                           @PathVariable("prNumber") int prNumber,
+                           @RequestBody Map<String, String> body);
 
     @Data
     @AllArgsConstructor

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
@@ -7,6 +7,7 @@ import com.societegenerale.cidroid.tasks.consumer.services.exceptions.GitHubAuth
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.*;
 import feign.*;
 import feign.codec.ErrorDecoder;
+import feign.httpclient.ApacheHttpClient;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.slf4j.Slf4jLogger;
@@ -148,7 +149,7 @@ public interface FeignRemoteGitHub extends RemoteGitHub {
 
     @Override
     default void closePullRequest(String repoFullName, int prNumber) {
-        HashMap<String, String> body = new HashMap<>();
+        Map<String, String> body = new HashMap<>();
         body.put("state", "closed");
 
         updatePullRequest(repoFullName, prNumber, body);
@@ -184,6 +185,11 @@ class RemoteGitHubConfig {
     @Bean
     RequestInterceptor oauthTokenSetterInterceptor(@Value("${gitHub.oauthToken:#{null}}") String oauthToken) {
         return new OAuthInterceptor(oauthToken);
+    }
+
+    @Bean
+    Client apacheHttpClient() {
+        return new ApacheHttpClient();
     }
 
 }

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GithubEventListenerIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GithubEventListenerIT.java
@@ -14,6 +14,7 @@ import com.societegenerale.cidroid.tasks.consumer.services.notifiers.Notifier;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,7 +84,7 @@ public class GithubEventListenerIT {
             githubMockServer.start();
 
             await().atMost(5, SECONDS)
-                    .until(() -> assertThat(GitHubMock.hasStarted()));
+                    .until(() -> assertThat(GitHubMock.hasStarted()).isTrue());
 
             hasGitHubMockServerStarted = true;
         }
@@ -92,6 +93,12 @@ public class GithubEventListenerIT {
         notifier.getNotifications().clear();
 
         githubMockServer.updatePRmergeabilityStatus(PULL_REQUEST_ID,NOT_MERGEABLE);
+    }
+
+    @After
+    public void tearDown() {
+        githubMockServer.stop();
+        hasGitHubMockServerStarted = false;
     }
 
     @Test

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PullRequestCleaningIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PullRequestCleaningIT.java
@@ -1,0 +1,65 @@
+package com.societegenerale.cidroid.tasks.consumer.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.InfraConfig;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.GitHubMockServer;
+import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.verify.VerificationTimes;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+
+import static org.mockserver.model.HttpRequest.request;
+
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = { InfraConfig.class, TestConfig.class },
+        initializers = YamlFileApplicationContextInitializer.class)
+public class PullRequestCleaningIT {
+
+    private static final int GITHUB_MOCK_PORT = 9900;
+    private static final int PULL_REQUEST_ID = 1347;
+
+    @Autowired
+    private GithubEventListener githubEventListener;
+
+    private GitHubMockServer githubMockServer;
+    private PushEvent pushEvent;
+
+    @Before
+    public void setUp() throws IOException {
+        githubMockServer = new GitHubMockServer(GITHUB_MOCK_PORT);
+        githubMockServer.start();
+
+        String pushEventPayload = IOUtils.toString(
+                getClass().getClassLoader().getResourceAsStream("pushEvent.json"), "UTF-8");
+        pushEvent = new ObjectMapper().readValue(pushEventPayload, PushEvent.class);
+    }
+
+    @After
+    public void tearDown() {
+        githubMockServer.stop();
+    }
+
+    @Test
+    public void shouldCloseOldPullRequests() {
+        githubEventListener.onGitHubPushEventOnDefaultBranch(pushEvent);
+
+        new MockServerClient("localhost", GITHUB_MOCK_PORT).verify(
+                request()
+                        .withMethod("PATCH")
+                        .withPath("/api/v3/repos/baxterthehacker/public-repo/pulls/" + PULL_REQUEST_ID)
+                        .withBody("{\"state\":\"closed\"}"),
+                VerificationTimes.once()
+        );
+    }
+
+}

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PullRequestTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PullRequestTest.java
@@ -3,27 +3,37 @@ package com.societegenerale.cidroid.tasks.consumer.infrastructure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PullRequestTest {
 
-    ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private PullRequest pullRequest;
+
+    @Before
+    public void setUp() throws Exception {
+        String pullRequestAsString = IOUtils.toString(
+                getClass().getClassLoader().getResourceAsStream("singlePullRequest.json"), "UTF-8");
+
+        pullRequest = objectMapper.readValue(pullRequestAsString, PullRequest.class);
+    }
 
     @Test
-    public void fieldsAreDeserialized() throws IOException {
+    public void fieldsAreDeserialized() {
+        assertThat(pullRequest).isNotNull();
+        assertThat(pullRequest.getNumber()).isGreaterThan(0);
+    }
 
-        String prAsString = IOUtils
-                .toString(PullRequestTest.class.getClassLoader().getResourceAsStream("singlePullRequest.json"), "UTF-8");
-
-        PullRequest pr=objectMapper.readValue(prAsString,PullRequest.class);
-
-        assertThat(pr).isNotNull();
-        assertThat(pr.getNumber()).isGreaterThan(0);
-
+    @Test
+    public void dateIsCorrectlyDeserialized() {
+        LocalDateTime expectedDate = LocalDateTime.of(2011, 1, 26, 19, 1, 12);
+        assertThat(pullRequest.getCreationDate()).isEqualTo(expectedDate);
     }
 
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/TestConfig.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/TestConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.MailSender;
 
-import java.util.Arrays;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,7 +43,13 @@ public class TestConfig {
     @Bean
     public PushEventOnDefaultBranchHandler notificationsHandler(RemoteGitHub remoteGitHub, NotifierMock notifierMock) {
 
-        return new NotificationsHandler(remoteGitHub, Arrays.asList(notifierMock));
+        return new NotificationsHandler(remoteGitHub, Collections.singletonList(notifierMock));
+    }
+
+    @Bean
+    public PushEventOnDefaultBranchHandler pullRequestCleaningHandler(RemoteGitHub remoteGitHub) {
+
+        return new PullRequestCleaningHandler(remoteGitHub, LocalDateTime::now, 180);
     }
 
     @Bean

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/mocks/GitHubMock.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/mocks/GitHubMock.java
@@ -23,6 +23,8 @@ public class GitHubMock {
 
     private static boolean hasStarted = false;
 
+    private WebServer gitHubWebServer;
+
     public static boolean hasStarted() {
         return hasStarted;
     }
@@ -42,7 +44,7 @@ public class GitHubMock {
 
     public boolean start() {
 
-        WebServer gitHubWebServer = new WebServer();
+        gitHubWebServer = new WebServer();
         gitHubWebServer.configure(
                 routes -> {
                     routes.get("/api/v3/repos/baxterthehacker/public-repo/pulls?state=open", context -> getOpenPullRequests());
@@ -123,6 +125,10 @@ public class GitHubMock {
         openPullRequestsFetchCount =0;
         hitsPerPullRequestNumber.clear();
         commentsPerPr.clear();
+    }
+
+    public void stop() {
+        gitHubWebServer.stop();
     }
 
 }

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/mocks/GitHubMockServer.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/mocks/GitHubMockServer.java
@@ -1,0 +1,85 @@
+package com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+
+@Slf4j
+public class GitHubMockServer {
+
+    private ClientAndServer githubMockServer;
+
+    private int port;
+
+    public GitHubMockServer(int port) {
+        this.port = port;
+    }
+
+    public void start() {
+        if (githubMockServer != null && githubMockServer.isRunning()) {
+            return;
+        }
+        githubMockServer = startClientAndServer(port);
+        initRoutes();
+    }
+
+    public void stop() {
+        githubMockServer.stop();
+    }
+
+    private void initRoutes() {
+        githubMockServer
+                .when(request()
+                        .withMethod("GET")
+                        .withPath("/api/v3/repos/baxterthehacker/public-repo/pulls")
+                        .withQueryStringParameter("status", "open"))
+                .respond(getOpenPullRequests());
+
+        githubMockServer
+                .when(request()
+                        .withMethod("GET")
+                        .withPath("/api/v3/repos/baxterthehacker/public-repo/pulls/[0-9]+"))
+                .respond(getPullRequest());
+
+        githubMockServer
+                .when(request()
+                        .withMethod("GET")
+                        .withPath("/api/v3/users/baxterthehacker"))
+                .respond(getUser());
+    }
+
+    private HttpResponse getOpenPullRequests() {
+        return HttpResponse.response()
+                .withBody(readFromFile("pullRequests.json"))
+                .withHeader("Content-Type", "application/json");
+    }
+
+    private HttpResponse getPullRequest() {
+        return HttpResponse.response()
+                .withBody(readFromFile("singlePullRequest.json"))
+                .withHeader("Content-Type", "application/json");
+    }
+
+    private HttpResponse getUser() {
+        return HttpResponse.response()
+                .withBody(readFromFile("user.json"))
+                .withHeader("Content-Type", "application/json");
+    }
+
+    private String readFromFile(String fileName) {
+        InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(fileName);
+        try {
+            return IOUtils.toString(Objects.requireNonNull(resourceAsStream), "UTF-8");
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("The file %s does not exist", fileName));
+        }
+    }
+}

--- a/ci-droid-tasks-consumer-infrastructure/src/test/resources/application-test.yml
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/resources/application-test.yml
@@ -18,6 +18,8 @@ ciDroidBehavior:
 # whenPushOnDefaultBranch:
   tryToRebaseOpenPrs.enabled: true
   notifyOwnerForNonMergeablePr.enabled: true
+  closeOldPullRequests.enabled: true
+  closeOldPullRequests.limitInDays: 180
 # whenPullRequestEvent:
   bestPracticeNotifier.enabled: true
   patternToResourceMapping:

--- a/ci-droid-tasks-consumer-services/pom.xml
+++ b/ci-droid-tasks-consumer-services/pom.xml
@@ -85,5 +85,10 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/RemoteGitHub.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/RemoteGitHub.java
@@ -27,10 +27,13 @@ public interface RemoteGitHub {
 
     ResourceContent fetchContent(String repoFullName, String path, String branch);
 
-    UpdatedResource updateContent(String repoFullName, String path, DirectCommit directCommit, String oauthToken) throws
-            GitHubAuthorizationException;
+    UpdatedResource updateContent(String repoFullName, String path, DirectCommit directCommit, String oauthToken)
+            throws GitHubAuthorizationException;
 
-    PullRequest createPullRequest(String repoFullName, PullRequestToCreate newPr, String oauthToken)throws GitHubAuthorizationException;
+    PullRequest createPullRequest(String repoFullName, PullRequestToCreate newPr, String oauthToken)
+            throws GitHubAuthorizationException;
+
+    void closePullRequest(String repoFullName, int prNumber);
 
     Optional<Repository> fetchRepository(String repoFullName);
 

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/actionHandlers/PullRequestCleaningHandler.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/actionHandlers/PullRequestCleaningHandler.java
@@ -1,0 +1,47 @@
+package com.societegenerale.cidroid.tasks.consumer.services.actionHandlers;
+
+import com.societegenerale.cidroid.tasks.consumer.services.RemoteGitHub;
+import com.societegenerale.cidroid.tasks.consumer.services.model.DateProvider;
+import com.societegenerale.cidroid.tasks.consumer.services.model.GitHubEvent;
+import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+public class PullRequestCleaningHandler implements PushEventOnDefaultBranchHandler {
+
+    private RemoteGitHub remoteGitHub;
+    private DateProvider dateProvider;
+
+    private int prAgeLimitInDays;
+
+    public PullRequestCleaningHandler(RemoteGitHub remoteGitHub,
+                                      DateProvider dateProvider,
+                                      int prAgeLimitInDays) {
+        this.remoteGitHub = remoteGitHub;
+        this.dateProvider = dateProvider;
+        this.prAgeLimitInDays = prAgeLimitInDays;
+    }
+
+    @Override
+    public void handle(GitHubEvent event, List<PullRequest> pullRequests) {
+        String repoFullName = event.getRepository().getFullName();
+
+        pullRequests.stream()
+                .filter(this::isPullRequestTooOld)
+                .forEach(pullRequest -> closePullRequest(repoFullName, pullRequest));
+    }
+
+    private boolean isPullRequestTooOld(PullRequest pullRequest) {
+        LocalDateTime creationDate = pullRequest.getCreationDate();
+        LocalDateTime today = dateProvider.now();
+        return creationDate.plusDays(prAgeLimitInDays).isBefore(today);
+    }
+
+    private void closePullRequest(String repoFullName, PullRequest pullRequest) {
+        remoteGitHub.closePullRequest(repoFullName, pullRequest.getNumber());
+    }
+
+}

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/DateProvider.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/DateProvider.java
@@ -1,0 +1,9 @@
+package com.societegenerale.cidroid.tasks.consumer.services.model;
+
+import java.time.LocalDateTime;
+
+public interface DateProvider {
+
+    LocalDateTime now();
+
+}

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/GitHubEvent.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/GitHubEvent.java
@@ -1,6 +1,9 @@
 package com.societegenerale.cidroid.tasks.consumer.services.model;
 
+import com.societegenerale.cidroid.tasks.consumer.services.model.github.Repository;
+
 public interface GitHubEvent {
 
-    String getRepositoryUrl();
+    Repository getRepository();
+
 }

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PullRequest.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PullRequest.java
@@ -5,12 +5,18 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.beans.ConstructorProperties;
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Data
@@ -34,6 +40,14 @@ public class PullRequest {
 
     private String branchStartedFromCommit;
 
+    @JsonProperty("created_at")
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime creationDate;
+
+    @JsonProperty("html_url")
+    private String htmlUrl;
+
     @JsonIgnore
     private boolean isMadeFromForkedRepo;
 
@@ -43,10 +57,8 @@ public class PullRequest {
     @JsonIgnore
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
-    private ObjectMapper objectMapper=new ObjectMapper();
-
-    @JsonProperty("html_url")
-    private String htmlUrl;
+    private ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
 
     @ConstructorProperties({ "number" })
     @JsonCreator
@@ -60,7 +72,7 @@ public class PullRequest {
 
     public PRmergeableStatus getMergeStatus(){
 
-       return PRmergeableStatus.mapping.get(mergeable);
+        return PRmergeableStatus.mapping.get(mergeable);
 
     }
 
@@ -77,8 +89,8 @@ public class PullRequest {
     private void unpackNestedHeadProperty(Map<String,Object> base) {
         this.branchName=(String)base.get("ref");
 
-       Repository repoFromWhichPrOriginates=objectMapper.convertValue(base.get("repo"), Repository.class);
-       isMadeFromForkedRepo=repoFromWhichPrOriginates.isFork();
+        Repository repoFromWhichPrOriginates=objectMapper.convertValue(base.get("repo"), Repository.class);
+        isMadeFromForkedRepo=repoFromWhichPrOriginates.isFork();
     }
 
 }

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PullRequestEvent.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PullRequestEvent.java
@@ -21,7 +21,7 @@ public class PullRequestEvent implements GitHubEvent {
     private Repository repository;
 
     @Override
-    public String getRepositoryUrl() {
-        return getRepository().getUrl();
+    public Repository getRepository() {
+        return repository;
     }
 }

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PushEvent.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PushEvent.java
@@ -17,8 +17,8 @@ public class PushEvent implements GitHubEvent {
     private Commit headCommit;
 
     @Override
-    public String getRepositoryUrl() {
-        return getRepository().getUrl();
+    public Repository getRepository() {
+        return repository;
     }
 
     public boolean happenedOnDefaultBranch(){

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/actionHandlers/PullRequestCleaningHandlerTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/actionHandlers/PullRequestCleaningHandlerTest.java
@@ -1,0 +1,69 @@
+package com.societegenerale.cidroid.tasks.consumer.services.actionHandlers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.societegenerale.cidroid.tasks.consumer.services.RemoteGitHub;
+import com.societegenerale.cidroid.tasks.consumer.services.model.DateProvider;
+import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
+import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static com.societegenerale.cidroid.tasks.consumer.services.TestUtils.readFromInputStream;
+import static org.mockito.Mockito.*;
+
+public class PullRequestCleaningHandlerTest {
+
+    private static final int PR_AGE_LIMIT_IN_DAYS = 180;
+
+    private PullRequestCleaningHandler pullRequestCleaningHandler;
+    private RemoteGitHub remoteGitHub;
+    private DateProvider dateProvider;
+    private PushEvent pushEvent;
+
+    @Before
+    public void setUp() throws IOException {
+        remoteGitHub = mock(RemoteGitHub.class);
+
+        dateProvider = () -> LocalDateTime.of(2018, 12, 23, 16, 0, 0);
+
+        pullRequestCleaningHandler = new PullRequestCleaningHandler(
+                remoteGitHub,
+                dateProvider,
+                PR_AGE_LIMIT_IN_DAYS
+        );
+
+        String pushEventPayload = readFromInputStream(getClass().getResourceAsStream("/pushEvent.json"));
+        pushEvent = new ObjectMapper().readValue(pushEventPayload, PushEvent.class);
+    }
+
+    @Test
+    public void shouldClosePRWhichOutlivedTheLimit() {
+        int pullRequestNumber = 7;
+        LocalDateTime oldDate = dateProvider.now().minusDays(PR_AGE_LIMIT_IN_DAYS + 10);
+        PullRequest oldPullRequest = new PullRequest(pullRequestNumber);
+        oldPullRequest.setCreationDate(oldDate);
+
+        pullRequestCleaningHandler.handle(pushEvent, Collections.singletonList(oldPullRequest));
+
+        String expectedRepositoryName = pushEvent.getRepository().getFullName();
+        verify(remoteGitHub, times(1))
+                .closePullRequest(expectedRepositoryName, pullRequestNumber);
+    }
+
+    @Test
+    public void shouldNotClosePRWhichAgeIsBelowTheLimit() {
+        int pullRequestNumber = 5;
+        LocalDateTime recentDate = dateProvider.now().minusDays(1);
+        PullRequest recentPullRequest = new PullRequest(pullRequestNumber);
+        recentPullRequest.setCreationDate(recentDate);
+
+        pullRequestCleaningHandler.handle(pushEvent, Collections.singletonList(recentPullRequest));
+
+        verifyZeroInteractions(remoteGitHub);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <spring-cloud-stream.version>Ditmars.SR3</spring-cloud-stream.version>
         <spring-cloud.version>Edgware.SR2</spring-cloud.version>
         <spring.cloud.feign.version>1.3.4.RELEASE</spring.cloud.feign.version>
+        <feign-httpclient.version>8.18.0</feign-httpclient.version>
         <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
 
         <lombok.version>1.18.2</lombok.version>
@@ -138,6 +139,12 @@
                         <artifactId>feign-hystrix</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.netflix.feign</groupId>
+                <artifactId>feign-httpclient</artifactId>
+                <version>${feign-httpclient.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <jackson.version>2.9.5</jackson.version>
 
         <net.code-story.version>2.104</net.code-story.version>
+        <mockserver.version>5.5.1</mockserver.version>
         <awaitility.version>1.7.0</awaitility.version>
         <greenmail.version>1.5.6</greenmail.version>
         <fakir.version>1.0.10</fakir.version>
@@ -79,7 +80,6 @@
 
         <ci-droid-api.version>1.0.5</ci-droid-api.version>
         <ci-droid-extensions.version>1.0.6</ci-droid-extensions.version>
-
     </properties>
 
     <!-- required by maven-release-plugin -->
@@ -223,6 +223,17 @@
                 <artifactId>http</artifactId>
                 <version>${net.code-story.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mock-server</groupId>
+                <artifactId>mockserver-netty</artifactId>
+                <version>${mockserver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mock-server</groupId>
+                <artifactId>mockserver-client-java</artifactId>
+                <version>${mockserver.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Summary

When something is pushed on the default branch of a repository, all the open pull requests are scanned. If their age is greater than the limit (which default value is 6 months), ci-droid automatically closes them.

## Details

I tried to split everything into small commits:

- [Add creationDate field on PullRequest](https://github.com/juliette-derancourt/ci-droid-tasks-consumer/commit/5a5d14a74bd9548b25e83e6ba931e395ce6b0d47): Deserialize the "created_at" date sent by GitHub API using jackson-datatype-jsr310
- [Call GitHub API to close a pull request](https://github.com/juliette-derancourt/ci-droid-tasks-consumer/commit/acac1f4739eac57048de4d3a090cffcb0cacc189): Send a PATCH request to GitHub API to change the state of the pull request from "open" to "closed"
- [Clean old pull requests when a push on default branch is made](https://github.com/juliette-derancourt/ci-droid-tasks-consumer/commit/e4693a67be51ea8f4ab181be6645b665b5a2dd39): Create a PullRequestCleaningHandler implementation of PushEventOnDefaultBranchHandler which goes through all open pull requests and close the ones that outlived the limit
- [Register the new PullRequestCleaningHandler](https://github.com/juliette-derancourt/ci-droid-tasks-consumer/commit/b4c04e1af73759d4524f0d6dac1a5b323024adf3): Add the handler to the configuration only if the feature was enabled in the application.yml file
- [Integration test for the pull request cleaning feature](https://github.com/juliette-derancourt/ci-droid-tasks-consumer/commit/5ef6d3c3b0c158e798a81af7816544f64da8fc6b): This was the most painful part. At first, I simply wanted to add a test case to [GithubEventListenerIT](https://github.com/societe-generale/ci-droid-tasks-consumer/blob/a1f1742111c5562dfd4f3b02547b08d0622f38bd/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GithubEventListenerIT.java) to test my new handler. Problem is, the current implementation of [GitHubMock](https://github.com/societe-generale/ci-droid-tasks-consumer/blob/a1f1742111c5562dfd4f3b02547b08d0622f38bd/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/mocks/GitHubMock.java) is based on [fluent-http](https://github.com/CodeStory/fluent-http), which doesn't support PATCH http methods. That's why I made a new mock using [MockServer](https://github.com/jamesdbloom/mockserver). It could be merged with the existing GitHubMock (which would need a bit of refactoring anyway) to avoid redundancies, but I didn't want to pollute this PR since it's already too big.
- [Add feign-httpclient to support PATCH requests](https://github.com/juliette-derancourt/ci-droid-tasks-consumer/commit/103a7a9191df377b65106f9741f8757351da8229): It appeared to me that Spring Cloud Feign does not support PATCH methods. I had to add the com.netflix.feign:feign-httpclient dependency and register an [ApacheHttpClient](https://github.com/juliette-derancourt/ci-droid-tasks-consumer/blob/103a7a9191df377b65106f9741f8757351da8229/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java#L191) for it to do so.


## Checklist:

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR

## Related issue :

[Issue #44](https://github.com/societe-generale/ci-droid-tasks-consumer/issues/44)