### PR TITLE
upgrading jackson version to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <janino.version>3.0.6</janino.version>
         <jgit.version>4.10.0.201712302008-r</jgit.version>
         <commons-lang3.version>3.7</commons-lang3.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
 
         <net.code-story.version>2.104</net.code-story.version>
         <awaitility.version>1.7.0</awaitility.version>


### PR DESCRIPTION
several CVEs reported with current jackson version - upgrading to 2.9.8, in which CVEs are fixed