### PR TITLE
Fix uri parameter name in fetchOpenPullRequests

### DIFF
--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
@@ -32,7 +32,7 @@ import static feign.FeignException.errorStatus;
 public interface FeignRemoteGitHub extends RemoteGitHub {
 
     @RequestMapping(method = RequestMethod.GET,
-            value = "/repos/{repoFullName}/pulls?status=open",
+            value = "/repos/{repoFullName}/pulls?state=open",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Override

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/mocks/GitHubMockServer.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/mocks/GitHubMockServer.java
@@ -40,7 +40,7 @@ public class GitHubMockServer {
                 .when(request()
                         .withMethod("GET")
                         .withPath("/api/v3/repos/baxterthehacker/public-repo/pulls")
-                        .withQueryStringParameter("status", "open"))
+                        .withQueryStringParameter("state", "open"))
                 .respond(getOpenPullRequests());
 
         githubMockServer


### PR DESCRIPTION
## Summary

Fixing issue in a GitHub call URI.

## Details

The GET call to retrieve all open pull requests was done on `/repos/{owner}/{repo}/pulls?status=open` instead of `/repos/{owner}/{repo}/pulls?state=open`.
We can see it [here](https://developer.github.com/v3/pulls/#list-pull-requests) that the right parameter name is indeed **state**.

## Context

The reason why it was working even though the name was wrong is that the default behavior of `/repos/{owner}/{repo}/pulls` is to return only open pull requests (as we can see here: https://api.github.com/repos/societe-generale/ci-droid-tasks-consumer/pulls).
This change is therefore not necessary, but it adds some clarity.