### PR TITLE
catching unexpected exceptions that may happen during PR creation

### DIFF
--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHub.java
@@ -271,7 +271,7 @@ class BranchCreationErrorDecoder implements ErrorDecoder {
     public Exception decode(String methodKey, Response response) {
 
         if (response.status() == 422) {
-            return new BranchAlreadyExistsException("Branch seems to already exist : " + response.reason());
+            return new BranchAlreadyExistsException("Branch or PR seems to already exist : " + response.reason());
         }
 
         if (response.status() == 401) {

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/ActionToPerformService.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/ActionToPerformService.java
@@ -334,6 +334,10 @@ public class ActionToPerformService {
             log.warn("issue while creating the PR",e);
             return Optional.empty();
         }
+        catch(Exception e){
+            log.warn("unknown issue while creating PR",e);
+            return Optional.empty();
+        }
     }
 
 }

--- a/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/ActionToPerformService.java
+++ b/ci-droid-tasks-consumer-services/src/main/java/com/societegenerale/cidroid/tasks/consumer/services/ActionToPerformService.java
@@ -76,7 +76,7 @@ public class ActionToPerformService {
                             action.getGitHubOauthToken());
                 } catch (BranchAlreadyExistsException e) {
 
-                    log.warn("branch " + branchNameForPR + " already exists");
+                    log.warn("branch " + branchNameForPR + " already exists, reusing it");
 
                     //TODO maybe we should add field in Reference to identify when it hasn't been created as expected
                     branchToUseForPr = remoteGitHub.fetchHeadReferenceFrom(repoFullName, branchNameForPR);


### PR DESCRIPTION
## Summary

In some scenarios during which input is invalid (trying to create a PR from master to master for instance), processing may fail without giving proper notification to end user

## Details

Unexpected exceptions need to be caught at PR creation time, to be able to provide relevant notification

- [X] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR

