### PR TITLE
Junit5 migration - without using TmpDir 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- PR #65 - all tests now running with Junit 5. Junit 4.x totally excluded now.
 
 ### Deprecated
 

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -20,15 +20,22 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -33,10 +33,7 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-        </dependency>
+
 
         <dependency>
             <groupId>com.icegreen</groupId>

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -38,19 +38,11 @@
         <dependency>
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.oneeyedmen</groupId>
             <artifactId>fakir</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -92,7 +84,6 @@
         <dependency>
             <groupId>com.jayway.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -108,15 +99,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
 
     </dependencies>
 </project>

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -42,6 +42,12 @@
             <groupId>com.icegreen</groupId>
             <artifactId>greenmail</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -106,6 +112,12 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/ActionToPerformCommandTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/ActionToPerformCommandTest.java
@@ -3,7 +3,7 @@ package com.societegenerale.cidroid.tasks.consumer.infrastructure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.api.gitHubInteractions.PullRequestGitHubInteraction;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/ActionToPerformListenerLIVETest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/ActionToPerformListenerLIVETest.java
@@ -2,19 +2,19 @@ package com.societegenerale.cidroid.tasks.consumer.infrastructure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.InfraConfig;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {InfraConfig.class, MailSenderAutoConfiguration.class, LiveTestForActionToPerformListenerConfig.class}, initializers = YamlFileApplicationContextInitializer.class)
 @TestPropertySource("/application-test.yml")
-@Ignore("to launch manually and test in local on 'real' actionToPerform documents")
+@Disabled("to launch manually and test in local on 'real' actionToPerform documents")
 public class ActionToPerformListenerLIVETest {
 
     @Autowired

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/ActionToPerformListenerTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/ActionToPerformListenerTest.java
@@ -10,8 +10,9 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.BulkActionToPer
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.User;
 import com.societegenerale.cidroid.tasks.consumer.services.notifiers.ActionNotifier;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class ActionToPerformListenerTest {
 
     private ActionToPerformCommand incomingCommand;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
 
         String incomingCommandAsString = IOUtils

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHubLIVETest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/FeignRemoteGitHubLIVETest.java
@@ -7,20 +7,20 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.github.Comment;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.DirectCommit;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.ResourceContent;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.UpdatedResource;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes={ InfraConfig.class,LiveTestConfig.class}, initializers = YamlFileApplicationContextInitializer.class)
 @TestPropertySource("/application-test.yml")
-@Ignore("to launch manually and test in local - you probably need to update config before running")
+@Disabled("to launch manually and test in local - you probably need to update config before running")
 public class FeignRemoteGitHubLIVETest {
 
     @Autowired

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GitRebaserTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GitRebaserTest.java
@@ -29,6 +29,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -36,7 +37,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class GitRebaserTest {
 
-    static String tmpFolderName="."+File.separator+"target"+File.separator+"GitRebaserTest-tmpDir-"+ Instant.now().toEpochMilli() ;
+    private static String tmpFolderName="."+File.separator+"target"+File.separator+"GitRebaserTest-tmpDir-"+ Instant.now().toEpochMilli() ;
 
     GitWrapper mockGitWrapper=mock(GitWrapper.class);
 
@@ -340,7 +341,7 @@ public class GitRebaserTest {
         File tmpFolder=new File(tmpFolderName);
 
         if(!tmpFolder.exists() && !tmpFolder.mkdirs()){
-            throw new RuntimeException("couldn't create tmp dir");
+           fail("couldn't create tmp dir");
         }
 
         Git git = Git.init().setDirectory(tmpFolder).call();

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GitRebaserTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GitRebaserTest.java
@@ -12,17 +12,16 @@ import org.eclipse.jgit.api.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.HashSet;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -37,8 +36,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class GitRebaserTest {
 
-    @Rule
-    public TemporaryFolder tmpFolder = new TemporaryFolder();
+    static String tmpFolderName="."+File.separator+"target"+File.separator+"GitRebaserTest-tmpDir-"+ Instant.now().toEpochMilli() ;
 
     GitWrapper mockGitWrapper=mock(GitWrapper.class);
 
@@ -58,7 +56,7 @@ public class GitRebaserTest {
 
     CheckoutCommand mockCheckoutCommand = mock(CheckoutCommand.class);
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException, GitAPIException {
 
         File tmpDirectory = createWorkingDirIfRequired();
@@ -125,7 +123,7 @@ public class GitRebaserTest {
 
     }
 
-    @After
+    @AfterEach
     public void assertGitIsClosed() throws GitAPIException {
 
         verify(mockGit, times(1)).close();
@@ -335,11 +333,17 @@ public class GitRebaserTest {
     }
 
     /**
-     * Impossible to mock RevCommit with Mockito (some methods are final), so non choice but build a tmp Git repo to build RevCommit instances
+     * Impossible to mock RevCommit with Mockito (some methods are final), so no choice but build a tmp Git repo to build RevCommit instances
      */
     private RevCommit buildRevCommit(String fileName, String content) throws GitAPIException, IOException {
 
-        Git git = Git.init().setDirectory(tmpFolder.getRoot()).call();
+        File tmpFolder=new File(tmpFolderName);
+
+        if(!tmpFolder.exists() && !tmpFolder.mkdirs()){
+            throw new RuntimeException("couldn't create tmp dir");
+        }
+
+        Git git = Git.init().setDirectory(tmpFolder).call();
 
         File file = new File(git.getRepository().getWorkTree(), fileName);
         try (FileOutputStream os = new FileOutputStream(file)) {

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GitRebaserTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GitRebaserTest.java
@@ -21,8 +21,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.HashSet;
+import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -36,8 +36,6 @@ import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class GitRebaserTest {
-
-    private static String tmpFolderName="."+File.separator+"target"+File.separator+"GitRebaserTest-tmpDir-"+ Instant.now().toEpochMilli() ;
 
     GitWrapper mockGitWrapper=mock(GitWrapper.class);
 
@@ -337,6 +335,8 @@ public class GitRebaserTest {
      * Impossible to mock RevCommit with Mockito (some methods are final), so no choice but build a tmp Git repo to build RevCommit instances
      */
     private RevCommit buildRevCommit(String fileName, String content) throws GitAPIException, IOException {
+
+        String tmpFolderName="."+File.separator+"target"+File.separator+"GitRebaserTest-tmpDir-"+ UUID.randomUUID() ;
 
         File tmpFolder=new File(tmpFolderName);
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GithubEventListenerLIVETest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GithubEventListenerLIVETest.java
@@ -4,18 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.InfraConfig;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import org.apache.commons.io.IOUtils;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes={ InfraConfig.class,LiveTestConfig.class}, initializers = YamlFileApplicationContextInitializer.class)
 @TestPropertySource("/application-test.yml")
-@Ignore("to launch manually and test in local on 'real' pushEvent documents")
+@Disabled("to launch manually and test in local on 'real' pushEvent documents")
 public class GithubEventListenerLIVETest {
 
     @Autowired

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GithubEventListenerTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/GithubEventListenerTest.java
@@ -6,8 +6,8 @@ import com.societegenerale.cidroid.tasks.consumer.services.PushEventOnDefaultBra
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequestEvent;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -25,7 +25,7 @@ public class GithubEventListenerTest {
 
     private GithubEventListener listener;
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         listener=new GithubEventListener(mockPushOnDefaultBranchService, mockPullRequestEventService);

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PullRequestTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PullRequestTest.java
@@ -3,8 +3,8 @@ package com.societegenerale.cidroid.tasks.consumer.infrastructure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
@@ -16,7 +16,7 @@ public class PullRequestTest {
 
     private PullRequest pullRequest;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         String pullRequestAsString = IOUtils.toString(
                 getClass().getClassLoader().getResourceAsStream("singlePullRequest.json"), "UTF-8");

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PushEventTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/PushEventTest.java
@@ -3,7 +3,7 @@ package com.societegenerale.cidroid.tasks.consumer.infrastructure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/RebaseHandlerLIVETest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/RebaseHandlerLIVETest.java
@@ -8,22 +8,22 @@ import com.societegenerale.cidroid.tasks.consumer.services.eventhandlers.RebaseH
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { InfraConfig.class, LiveTestConfig.class }, initializers = YamlFileApplicationContextInitializer.class)
 @TestPropertySource("/application-test.yml")
-@Ignore("to launch manually and test in local")
+@Disabled("to launch manually and test in local")
 public class RebaseHandlerLIVETest {
 
     @Autowired
@@ -38,7 +38,7 @@ public class RebaseHandlerLIVETest {
 
     RebaseHandler rebaseHandler;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/RebaserLIVETest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/RebaserLIVETest.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.services.Rebaser;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import org.apache.commons.io.IOUtils;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-@Ignore("to launch manually and test in local on 'real' pullRequest documents")
+@Disabled("to launch manually and test in local on 'real' pullRequest documents")
 public class RebaserLIVETest {
 
     Rebaser rebaser = new GitRebaser("userOne", "yourPassword", new GitWrapper());

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/ActionToPerformEventHandlerIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/ActionToPerformEventHandlerIT.java
@@ -6,19 +6,19 @@ import com.societegenerale.cidroid.tasks.consumer.infrastructure.TestConfig;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.YamlFileApplicationContextInitializer;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.InfraConfig;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.GitHubMockServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockserver.client.MockServerClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 
 import static com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.GitHubMockServer.GITHUB_MOCK_PORT;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { InfraConfig.class, TestConfig.class },
         initializers = YamlFileApplicationContextInitializer.class)
 public abstract class ActionToPerformEventHandlerIT {
@@ -33,15 +33,15 @@ public abstract class ActionToPerformEventHandlerIT {
 
     protected ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
-    public void setUp() throws IOException {
+    @BeforeEach
+    public void setUp(){
         githubMockServer.start();
 
         gitHubMockClient = new MockServerClient("localhost", GITHUB_MOCK_PORT);
 
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         githubMockServer.stop();
     }

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/BulkActionToPerformIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/BulkActionToPerformIT.java
@@ -1,7 +1,7 @@
 package com.societegenerale.cidroid.tasks.consumer.infrastructure.handlers;
 
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.ActionToPerformCommand;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockserver.matchers.MatchType;
 import org.mockserver.verify.VerificationTimes;
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/GitHubEventHandlerIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/GitHubEventHandlerIT.java
@@ -8,19 +8,21 @@ import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.InfraCon
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.GitHubMockServer;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockserver.client.MockServerClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 
 import static com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.GitHubMockServer.GITHUB_MOCK_PORT;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { InfraConfig.class, TestConfig.class },
         initializers = YamlFileApplicationContextInitializer.class)
 public abstract class GitHubEventHandlerIT {
@@ -38,7 +40,7 @@ public abstract class GitHubEventHandlerIT {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         githubMockServer.start();
 
@@ -48,7 +50,7 @@ public abstract class GitHubEventHandlerIT {
         pullRequest = (PullRequest) getObjectFromJson("singlePullRequest.json", PullRequest.class);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         githubMockServer.stop();
     }

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/PullRequestCleaningIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/PullRequestCleaningIT.java
@@ -1,6 +1,7 @@
 package com.societegenerale.cidroid.tasks.consumer.infrastructure.handlers;
 
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.mockserver.verify.VerificationTimes;
 
 import static org.mockserver.model.HttpRequest.request;

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/PullRequestNotificationsIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/PullRequestNotificationsIT.java
@@ -4,8 +4,8 @@ import com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.NotifierM
 import com.societegenerale.cidroid.tasks.consumer.services.model.Message;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.User;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.jayway.awaitility.Awaitility.await;
@@ -21,7 +21,7 @@ public class PullRequestNotificationsIT extends GitHubEventHandlerIT {
     @Autowired
     private NotifierMock notifier;
 
-    @Before
+    @BeforeEach
     public void setUpNotifier() {
         notifier.getNotifications().clear();
     }

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/PullRequestRebaseIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/PullRequestRebaseIT.java
@@ -5,7 +5,8 @@ import com.societegenerale.cidroid.tasks.consumer.services.Rebaser;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.mockserver.verify.VerificationTimes;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/notifiers/EMailNotifierTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/notifiers/EMailNotifierTest.java
@@ -6,9 +6,10 @@ import com.icegreen.greenmail.util.ServerSetupTest;
 import com.societegenerale.cidroid.tasks.consumer.services.model.Message;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.User;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 import javax.mail.MessagingException;
@@ -27,7 +28,7 @@ public class EMailNotifierTest {
 
     private GreenMail mailServer = new GreenMail(ServerSetupTest.SMTP);
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         emailNotifier = buildAndConfigure();
@@ -50,7 +51,7 @@ public class EMailNotifierTest {
         return new EMailNotifier(mailSenderImpl, MAIL_SENT_FROM);
     }
 
-    @After
+    @AfterEach
     public void stopGreenMailServer() {
         mailServer.stop();
     }

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/notifiers/HttpNotifierTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/notifiers/HttpNotifierTest.java
@@ -3,9 +3,9 @@ package com.societegenerale.cidroid.tasks.consumer.infrastructure.notifiers;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.TargetHttpBackendForNotifier;
 import com.societegenerale.cidroid.tasks.consumer.services.model.Message;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.User;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.TargetHttpBackendForNotifier.TARGET_HTTP_BACKEND_MOCK_PORT;
 import static java.util.Collections.emptyMap;
@@ -17,7 +17,7 @@ public class HttpNotifierTest {
 
     private TargetHttpBackendForNotifier httpBackendServer;
 
-    @Before
+    @BeforeEach
     public void setUp(){
         String notifierUrl = "http://localhost:" + TARGET_HTTP_BACKEND_MOCK_PORT + "/notify";
         httpNotifier = new HttpNotifier(notifierUrl);
@@ -26,7 +26,7 @@ public class HttpNotifierTest {
         httpBackendServer.start();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         httpBackendServer.stop();
     }

--- a/ci-droid-tasks-consumer-services/pom.xml
+++ b/ci-droid-tasks-consumer-services/pom.xml
@@ -35,7 +35,16 @@
                     <artifactId>android-json</artifactId>
                     <groupId>com.vaadin.external.google</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
         </dependency>
 
 

--- a/ci-droid-tasks-consumer-services/pom.xml
+++ b/ci-droid-tasks-consumer-services/pom.xml
@@ -46,14 +46,12 @@
         <dependency>
             <groupId>com.jayway.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.oneeyedmen</groupId>
             <artifactId>fakir</artifactId>
-            <scope>test</scope>
-        </dependency>
+         </dependency>
 
         <dependency>
             <groupId>commons-io</groupId>

--- a/ci-droid-tasks-consumer-services/pom.xml
+++ b/ci-droid-tasks-consumer-services/pom.xml
@@ -27,22 +27,6 @@
 
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>android-json</artifactId>
-                    <groupId>com.vaadin.external.google</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/ActionNotificationServiceTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/ActionNotificationServiceTest.java
@@ -8,8 +8,8 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.github.UpdatedR
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.User;
 import com.societegenerale.cidroid.tasks.consumer.services.notifiers.ActionNotifier;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static com.societegenerale.cidroid.tasks.consumer.services.model.github.UpdatedResource.UpdateStatus.*;
@@ -48,7 +48,7 @@ public class ActionNotificationServiceTest {
 
     private BulkActionToPerform.BulkActionToPerformBuilder bulkActionToPerformBuilder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         testActionToPerform.setContentToProvide(MODIFIED_CONTENT);
         testActionToPerform.setContinueIfResourceDoesntExist(true);

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/ActionToPerformServiceTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/ActionToPerformServiceTest.java
@@ -13,9 +13,10 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.BulkActionToPer
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.*;
 import com.societegenerale.cidroid.tasks.consumer.services.monitoring.TestAppender;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +91,7 @@ public class ActionToPerformServiceTest {
 
     private BulkActionToPerform.BulkActionToPerformBuilder bulkActionToPerformBuilder;
 
-    @Before
+    @BeforeEach
     public void setUp() throws GitHubAuthorizationException {
 
         testActionToPerform.setContentToProvide(MODIFIED_CONTENT);
@@ -120,7 +121,7 @@ public class ActionToPerformServiceTest {
 
     }
 
-    @After
+    @AfterEach
     public void after() {
         assertAtLeastOneMonitoringEventOfType(BULK_ACTION_PROCESSED);
         testAppender.events.clear();

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/GitHubContentBase64codecTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/GitHubContentBase64codecTest.java
@@ -1,6 +1,6 @@
 package com.societegenerale.cidroid.tasks.consumer.services;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/PullRequestEventServiceTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/PullRequestEventServiceTest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.services.eventhandlers.PullRequestEventHandler;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequestEvent;
 import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -21,7 +21,7 @@ public class PullRequestEventServiceTest {
 
     PullRequestEvent pullRequestEvent;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
 
         pullRequestEventService = new PullRequestEventService(Arrays.asList(mockHandler));

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/PushEventOnDefaultBranchServiceTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/PushEventOnDefaultBranchServiceTest.java
@@ -8,8 +8,8 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.github.PRmergea
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.User;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -49,7 +49,7 @@ public class PushEventOnDefaultBranchServiceTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
 
         List<PushEventOnDefaultBranchHandler> pushEventOnDefaultBranchHandlers = new ArrayList<>();

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/BestPracticeNotifierHandlerTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/BestPracticeNotifierHandlerTest.java
@@ -9,8 +9,8 @@ import com.societegenerale.cidroid.tasks.consumer.services.ResourceFetcher;
 import com.societegenerale.cidroid.tasks.consumer.services.model.Message;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.*;
 import com.societegenerale.cidroid.tasks.consumer.services.notifiers.Notifier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class BestPracticeNotifierHandlerTest {
 
     private PullRequestEvent pullRequestEvent;
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         matchingPullRequestFile.setFilename(MATCHING_FILENAME);

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/NotificationsHandlerTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/NotificationsHandlerTest.java
@@ -7,8 +7,9 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequ
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.User;
 import com.societegenerale.cidroid.tasks.consumer.services.notifiers.Notifier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -38,7 +39,7 @@ public class NotificationsHandlerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
 
         String prAsString = readFromInputStream(getClass().getResourceAsStream(SINGLE_PULL_REQUEST_JSON));

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/PullRequestCleaningHandlerTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/PullRequestCleaningHandlerTest.java
@@ -8,8 +8,8 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.DateProvider;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequest;
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import com.societegenerale.cidroid.tasks.consumer.services.monitoring.TestAppender;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ public class PullRequestCleaningHandlerTest {
 
     private TestAppender testAppender=new TestAppender();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         remoteGitHub = mock(RemoteGitHub.class);
 

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/RebaseHandlerTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/eventhandlers/RebaseHandlerTest.java
@@ -10,8 +10,8 @@ import com.societegenerale.cidroid.tasks.consumer.services.model.github.PullRequ
 import com.societegenerale.cidroid.tasks.consumer.services.model.github.PushEvent;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -41,7 +41,7 @@ public class RebaseHandlerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
 
         String prAsString = readFromInputStream(getClass().getResourceAsStream(SINGLE_PULL_REQUEST_JSON));

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PullRequestCommentTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/PullRequestCommentTest.java
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.services.TestUtils;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/UpdatedResourceTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/model/github/UpdatedResourceTest.java
@@ -1,6 +1,6 @@
 package com.societegenerale.cidroid.tasks.consumer.services.model.github;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/monitoring/EventTest.java
+++ b/ci-droid-tasks-consumer-services/src/test/java/com/societegenerale/cidroid/tasks/consumer/services/monitoring/EventTest.java
@@ -2,8 +2,8 @@ package com.societegenerale.cidroid.tasks.consumer.services.monitoring;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
 import java.util.AbstractMap;
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class EventTest {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MDC.clear();
         TestAppender.events.clear();

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 
         <jacoco.version>0.8.2</jacoco.version>
         <guava.version>27.0-jre</guava.version>
+        <junit5.version>5.4.1</junit5.version>
 
         <ci-droid-api.version>1.0.6</ci-droid-api.version>
         <ci-droid-extensions.version>1.0.9</ci-droid-extensions.version>
@@ -141,6 +142,19 @@
             </dependency>
 
             <!-- Test -->
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit5.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit5.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>com.jayway.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,19 @@
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,12 @@
                 <artifactId>greenmail</artifactId>
                 <version>${greenmail.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -207,6 +213,12 @@
                 <artifactId>mockserver-netty</artifactId>
                 <version>${mockserver.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Summary

similar to https://github.com/societe-generale/ci-droid-tasks-consumer/pull/61 

## Details

All tests have been migrated including GitRebaserTest, which initially was an issue because of a temp directory rule. 
All Junit 4 have been excluded explicitly from dependency management, to avoid using them by mistake in the future


## Related issue : 
https://github.com/societe-generale/ci-droid-tasks-consumer/pull/61  