### PR TITLE
Enabling sync mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,17 @@ CI-droid tasks consumer will execute the boring tasks on behalf of the dev teams
 
 
 Main documentation is available [here](https://github.com/societe-generale/ci-droid).
+
+## Sync mode 
+
+In regular mode, CI-droid-tasks-controller receives events from an event bus (RabbitMq or Kafka, which are supported by Spring Cloud) : since processing a source control event may take some time, we usually prefer to respond immediately to source the control and ackoweledge the request, then process it asynchronously. 
+
+However, especially while prototyping, we may want a simpler setup without a messaging bus and CI-droid may be preferable. 
+
+For those situations, it's possible to start ci-droid-tasks-consumer in sync mode : instead of listening for events on the message bus, it will now listen to messages on a REST interface on `/cidroid-sync-webhook` endpoint.
+
+To achieve this : 
+
+- set `synchronous-mode` property to true
+- disable rabbit (or Kafka) autoconfig via `spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration`
+

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ For those situations, it's possible to start ci-droid-tasks-consumer in sync mod
 To achieve this : 
 
 - set `synchronous-mode` property to true
-- disable rabbit (or Kafka) autoconfig via `spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration`
+- disable rabbit (or Kafka) autoconfig via `spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration` property
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Main documentation is available [here](https://github.com/societe-generale/ci-dr
 
 ## Sync mode 
 
-In regular mode, CI-droid-tasks-controller receives events from an event bus (RabbitMq or Kafka, which are supported by Spring Cloud) : since processing a source control event may take some time, we usually prefer to respond immediately to source the control and ackoweledge the request, then process it asynchronously. 
+In regular mode, CI-droid-tasks-controller receives events from an event bus (RabbitMq or Kafka, which are supported by Spring Cloud) : since processing a source control event may take some time, we usually prefer to respond immediately to source the control and acknowledge the request, then process it asynchronously. 
 
 However, especially while prototyping, we may want a simpler setup without a messaging bus and CI-droid may be preferable. 
 

--- a/ci-droid-tasks-consumer-autoconfigure/src/main/java/com/societegenerale/cidroid/tasks/consumer/autoconfigure/AsyncConfig.java
+++ b/ci-droid-tasks-consumer-autoconfigure/src/main/java/com/societegenerale/cidroid/tasks/consumer/autoconfigure/AsyncConfig.java
@@ -1,0 +1,51 @@
+package com.societegenerale.cidroid.tasks.consumer.autoconfigure;
+
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.ActionToPerformCommand;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.ActionToPerformListener;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventListener;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventMapper;
+import com.societegenerale.cidroid.tasks.consumer.services.PullRequestEventService;
+import com.societegenerale.cidroid.tasks.consumer.services.PushEventService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.function.Consumer;
+
+@Configuration
+@ConditionalOnProperty(name = "synchronous-mode", havingValue = "false", matchIfMissing = true)
+public class AsyncConfig {
+
+    @Bean
+    public SourceControlEventListener pushOnMasterListener(PullRequestEventService pullRequestEventService,
+                                                           PushEventService pushEventService,
+                                                           SourceControlEventMapper eventMapper) {
+
+        return new SourceControlEventListener(pullRequestEventService,pushEventService,eventMapper);
+    }
+
+    @Bean(name = "push-on-default-branch")
+    public Consumer<String> msgConsumerPush(SourceControlEventListener actionToPerformListener) {
+
+        return  event -> {actionToPerformListener.onPushEventOnDefaultBranch(event);};
+    }
+
+    @Bean(name = "push-on-non-default-branch")
+    public Consumer<String> msgConsumerPushNonDefaultBranch(SourceControlEventListener actionToPerformListener) {
+
+        return  event -> {actionToPerformListener.onPushEventOnNonDefaultBranch(event);};
+    }
+
+    @Bean(name = "pull-request-event")
+    public Consumer<String> msgConsumerPREvent(SourceControlEventListener actionToPerformListener) {
+
+        return  event -> {actionToPerformListener.onPullRequestEvent(event);};
+    }
+
+    @Bean(name = "actions-to-perform")
+    public Consumer<ActionToPerformCommand> msgConsumer(ActionToPerformListener actionToPerformListener) {
+
+        return  action -> {actionToPerformListener.onActionToPerform(action);};
+    }
+
+}

--- a/ci-droid-tasks-consumer-autoconfigure/src/main/java/com/societegenerale/cidroid/tasks/consumer/autoconfigure/CiDroidTasksConsumerApplication.java
+++ b/ci-droid-tasks-consumer-autoconfigure/src/main/java/com/societegenerale/cidroid/tasks/consumer/autoconfigure/CiDroidTasksConsumerApplication.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import({CiDroidTasksConsumerAutoConfiguration.class})
+@Import({CiDroidTasksConsumerAutoConfiguration.class,AsyncConfig.class})
 @SuppressWarnings("squid:S1118") //can't add a private constructor, otherwise app won't start
 public class CiDroidTasksConsumerApplication {
 

--- a/ci-droid-tasks-consumer-autoconfigure/src/main/java/com/societegenerale/cidroid/tasks/consumer/autoconfigure/CiDroidTasksConsumerApplication.java
+++ b/ci-droid-tasks-consumer-autoconfigure/src/main/java/com/societegenerale/cidroid/tasks/consumer/autoconfigure/CiDroidTasksConsumerApplication.java
@@ -1,11 +1,12 @@
 package com.societegenerale.cidroid.tasks.consumer.autoconfigure;
 
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.AsyncConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
-@Import({CiDroidTasksConsumerAutoConfiguration.class,AsyncConfig.class})
+@Import({CiDroidTasksConsumerAutoConfiguration.class, AsyncConfig.class})
 @SuppressWarnings("squid:S1118") //can't add a private constructor, otherwise app won't start
 public class CiDroidTasksConsumerApplication {
 

--- a/ci-droid-tasks-consumer-autoconfigure/src/main/resources/application.yml
+++ b/ci-droid-tasks-consumer-autoconfigure/src/main/resources/application.yml
@@ -46,6 +46,10 @@ spring:
     virtual-host: ${ENVNAME}
     ssl.enabled: ${RABBITMQ_SSL}
 
+synchronous-mode: true
+spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+
+debug: true
 
 hystrix.command.default.execution.timeout.enabled: false
 feign.hystrix.enabled: false
@@ -53,10 +57,10 @@ feign.hystrix.enabled: false
 
 gitHub:
   api.url: "https://api.github.com"
-  oauthToken: ${SERVICE_ACCOUNT_GITHUB_OAUTH_TOKEN}
+  oauthToken: "blabla"
 #below credentials should be a service account credentials - they will be used to rebase PRs automatically using Git commands.
-  login: ${SERVICE_ACCOUNT_USERNAME}
-  password: ${SERVICE_ACCOUNT_PASSWORD}
+  login: "blabla"
+  password: "blabla"
 
 
 notifiers:

--- a/ci-droid-tasks-consumer-autoconfigure/src/main/resources/application.yml
+++ b/ci-droid-tasks-consumer-autoconfigure/src/main/resources/application.yml
@@ -46,8 +46,9 @@ spring:
     virtual-host: ${ENVNAME}
     ssl.enabled: ${RABBITMQ_SSL}
 
-synchronous-mode: true
-spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+# enable below config to be in synchronous mode without messaging bus
+#synchronous-mode: true
+#spring.autoconfigure.exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
 
 debug: true
 
@@ -57,10 +58,10 @@ feign.hystrix.enabled: false
 
 gitHub:
   api.url: "https://api.github.com"
-  oauthToken: "blabla"
+  oauthToken: ${SERVICE_ACCOUNT_GITHUB_OAUTH_TOKEN}
 #below credentials should be a service account credentials - they will be used to rebase PRs automatically using Git commands.
-  login: "blabla"
-  password: "blabla"
+  login: ${SERVICE_ACCOUNT_USERNAME}
+  password: ${SERVICE_ACCOUNT_PASSWORD}
 
 
 notifiers:

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
@@ -91,6 +96,12 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/ci-droid-tasks-consumer-infrastructure/pom.xml
+++ b/ci-droid-tasks-consumer-infrastructure/pom.xml
@@ -97,12 +97,6 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
 
     </dependencies>
 </project>

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/config/AsyncConfig.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/config/AsyncConfig.java
@@ -1,4 +1,6 @@
-package com.societegenerale.cidroid.tasks.consumer.autoconfigure;
+package com.societegenerale.cidroid.tasks.consumer.infrastructure.config;
+
+import java.util.function.Consumer;
 
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.ActionToPerformCommand;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.ActionToPerformListener;
@@ -9,8 +11,6 @@ import com.societegenerale.cidroid.tasks.consumer.services.PushEventService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.function.Consumer;
 
 @Configuration
 @ConditionalOnProperty(name = "synchronous-mode", havingValue = "false", matchIfMissing = true)

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/config/InfraConfig.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/config/InfraConfig.java
@@ -2,9 +2,7 @@ package com.societegenerale.cidroid.tasks.consumer.infrastructure.config;
 
 import com.societegenerale.cidroid.api.actionToReplicate.ActionToReplicate;
 import com.societegenerale.cidroid.extensions.actionToReplicate.*;
-import com.societegenerale.cidroid.tasks.consumer.infrastructure.ActionToPerformCommand;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.ActionToPerformListener;
-import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventListener;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventMapper;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.github.FeignRemoteGitHub;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.notifiers.EMailActionNotifier;
@@ -24,7 +22,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.MailSender;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 @Configuration
 @EnableFeignClients(clients = { FeignRemoteGitHub.class})
@@ -88,32 +85,6 @@ public class InfraConfig {
         return new ActionToPerformListener(actionToPerformService, actionsToReplicate, remoteSourceControl,actionNotifier);
     }
 
-    @Bean
-    @ConditionalOnProperty(name = "synchronous-mode", havingValue = "false", matchIfMissing = true)
-    public SourceControlEventListener pushOnMasterListener(PullRequestEventService pullRequestEventService,
-                                                           PushEventService pushEventService,
-                                                           SourceControlEventMapper eventMapper) {
-
-        return new SourceControlEventListener(pullRequestEventService,pushEventService,eventMapper);
-    }
-
-    @Bean(name = "push-on-default-branch")
-    public Consumer<String> msgConsumerPush(SourceControlEventListener actionToPerformListener) {
-
-        return  event -> {actionToPerformListener.onPushEventOnDefaultBranch(event);};
-    }
-
-    @Bean(name = "push-on-non-default-branch")
-    public Consumer<String> msgConsumerPushNonDefaultBranch(SourceControlEventListener actionToPerformListener) {
-
-        return  event -> {actionToPerformListener.onPushEventOnNonDefaultBranch(event);};
-    }
-
-    @Bean(name = "pull-request-event")
-    public Consumer<String> msgConsumerPREvent(SourceControlEventListener actionToPerformListener) {
-
-        return  event -> {actionToPerformListener.onPullRequestEvent(event);};
-    }
 
     @Bean
     @ConditionalOnProperty(name = "synchronous-mode", havingValue = "true")
@@ -164,10 +135,5 @@ public class InfraConfig {
         return new EMailActionNotifier(javaMailSender, mailSender);
     }
 
-    @Bean(name = "actions-to-perform")
-    public Consumer<ActionToPerformCommand> msgConsumer(ActionToPerformListener actionToPerformListener) {
-
-        return  action -> {actionToPerformListener.onActionToPerform(action);};
-    }
 
 }

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/config/InfraConfig.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/config/InfraConfig.java
@@ -8,12 +8,14 @@ import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEv
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventMapper;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.github.FeignRemoteGitHub;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.notifiers.EMailActionNotifier;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.rest.SourceControlEventController;
 import com.societegenerale.cidroid.tasks.consumer.services.*;
 import com.societegenerale.cidroid.tasks.consumer.services.eventhandlers.PullRequestEventHandler;
 import com.societegenerale.cidroid.tasks.consumer.services.eventhandlers.PushEventHandler;
 import com.societegenerale.cidroid.tasks.consumer.services.eventhandlers.PushEventMonitor;
 import com.societegenerale.cidroid.tasks.consumer.services.notifiers.ActionNotifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
@@ -87,6 +89,7 @@ public class InfraConfig {
     }
 
     @Bean
+    @ConditionalOnProperty(name = "synchronous-mode", havingValue = "false", matchIfMissing = true)
     public SourceControlEventListener pushOnMasterListener(PullRequestEventService pullRequestEventService,
                                                            PushEventService pushEventService,
                                                            SourceControlEventMapper eventMapper) {
@@ -111,6 +114,14 @@ public class InfraConfig {
 
         return  event -> {actionToPerformListener.onPullRequestEvent(event);};
     }
+
+    @Bean
+    @ConditionalOnProperty(name = "synchronous-mode", havingValue = "true")
+    public SourceControlEventController sourceControlEventController(PullRequestEventService pullRequestEventService, PushEventService pushEventService,SourceControlEventMapper sourceControlEventMapper) {
+
+        return new SourceControlEventController(pullRequestEventService, pushEventService,sourceControlEventMapper);
+    }
+
 
     @Bean
     public PushEventService pushEventService(RemoteSourceControl remoteSourceControl,

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventController.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventController.java
@@ -9,10 +9,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "/cidroid-sync-webhook")
+@RequestMapping(value = "/cidroid-sync-webhook/gitlab")
 @Slf4j
 public class SourceControlEventController {
 
@@ -29,11 +33,21 @@ public class SourceControlEventController {
     }
 
 
-    @PostMapping(headers = "X-Github-Event=push")
+    @PostMapping(value="/github",headers = "X-Github-Event=push")
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<?> onPushEvent(HttpEntity<String> rawPushEvent) {
+    public ResponseEntity<?> onGitHubPushEvent(HttpEntity<String> rawPushEvent) {
+        return processPushEvent(rawPushEvent);
+    }
 
+    @PostMapping(headers = "X-Gitlab-Event=Push Hook")
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<?> onGitLabPushEvent(HttpEntity<String> rawPushEvent) {
+        return processPushEvent(rawPushEvent);
+    }
+
+    private ResponseEntity<?> processPushEvent(HttpEntity<String> rawPushEvent) {
         PushEvent pushEvent=null;
         try {
             pushEvent=sourceControlEventMapper.deserializePushEvent(rawPushEvent.getBody());
@@ -54,7 +68,6 @@ public class SourceControlEventController {
 
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
-
     }
 
     @PostMapping(headers = "X-Github-Event=pull_request")

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventController.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventController.java
@@ -1,0 +1,83 @@
+package com.societegenerale.cidroid.tasks.consumer.infrastructure.rest;
+
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventMapper;
+import com.societegenerale.cidroid.tasks.consumer.services.PullRequestEventService;
+import com.societegenerale.cidroid.tasks.consumer.services.PushEventService;
+import com.societegenerale.cidroid.tasks.consumer.services.model.PullRequestEvent;
+import com.societegenerale.cidroid.tasks.consumer.services.model.PushEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value = "/cidroid-sync-webhook")
+@Slf4j
+public class SourceControlEventController {
+
+    private PushEventService pushEventService;
+
+    private PullRequestEventService pullRequestEventService;
+
+    private SourceControlEventMapper sourceControlEventMapper;
+
+    public SourceControlEventController(PullRequestEventService pullRequestEventService, PushEventService pushEventService, SourceControlEventMapper sourceControlEventMapper) {
+        this.pullRequestEventService = pullRequestEventService;
+        this.pushEventService = pushEventService;
+        this.sourceControlEventMapper=sourceControlEventMapper;
+    }
+
+
+    @PostMapping(headers = "X-Github-Event=push")
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<?> onPushEvent(HttpEntity<String> rawPushEvent) {
+
+        PushEvent pushEvent=null;
+        try {
+            pushEvent=sourceControlEventMapper.deserializePushEvent(rawPushEvent.getBody());
+
+            log.info("received event on branch {} for repo {}", pushEvent.getRef(), pushEvent.getRepository().getFullName());
+
+            if(pushEvent.happenedOnDefaultBranch()) {
+                pushEventService.onPushOnDefaultBranchEvent(pushEvent);
+            }
+            else{
+                pushEventService.onPushOnNonDefaultBranchEvent(pushEvent);
+            }
+
+            return ResponseEntity.accepted().build();
+
+        } catch (Exception e) {
+            log.warn("problem while processing the event {}", pushEvent, e);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+    }
+
+    @PostMapping(headers = "X-Github-Event=pull_request")
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<?> onPullRequestEvent(HttpEntity<String> rawPullRequestEvent) {
+
+        PullRequestEvent pullRequestEvent=null;
+
+        try {
+            pullRequestEvent = sourceControlEventMapper.deserializePullRequestEvent(rawPullRequestEvent.getBody());
+
+            log.info("received pullRequest event of type {} for repo {}", pullRequestEvent.getAction(), pullRequestEvent.getRepository().getFullName());
+
+            pullRequestEventService.onPullRequestEvent(pullRequestEvent);
+
+            return ResponseEntity.accepted().build();
+        }
+        catch (Exception e) {
+            log.warn("problem while processing the event {}",pullRequestEvent, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+
+}

--- a/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventController.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/main/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "/cidroid-sync-webhook/gitlab")
+@RequestMapping(value = "/cidroid-sync-webhook")
 @Slf4j
 public class SourceControlEventController {
 
@@ -40,7 +40,7 @@ public class SourceControlEventController {
         return processPushEvent(rawPushEvent);
     }
 
-    @PostMapping(headers = "X-Gitlab-Event=Push Hook")
+    @PostMapping(value="/gitlab", headers = "X-Gitlab-Event=Push Hook")
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<?> onGitLabPushEvent(HttpEntity<String> rawPushEvent) {
@@ -70,10 +70,24 @@ public class SourceControlEventController {
         }
     }
 
-    @PostMapping(headers = "X-Github-Event=pull_request")
+    @PostMapping(path="/github",headers = "X-Github-Event=pull_request")
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<?> onPullRequestEvent(HttpEntity<String> rawPullRequestEvent) {
+    public ResponseEntity<?> onGitHubPullRequestEvent(HttpEntity<String> rawPullRequestEvent) {
+
+        return processPullRequestEvent(rawPullRequestEvent);
+    }
+
+    @PostMapping(path="/gitlab",headers = "X-Gitlab-Event=Merge Request Hook")
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<?> onGitLabPullRequestEvent(HttpEntity<String> rawPullRequestEvent) {
+
+        return processPullRequestEvent(rawPullRequestEvent);
+    }
+
+    private ResponseEntity<?> processPullRequestEvent(HttpEntity<String> rawPullRequestEvent) {
+
 
         PullRequestEvent pullRequestEvent=null;
 
@@ -90,7 +104,8 @@ public class SourceControlEventController {
             log.warn("problem while processing the event {}",pullRequestEvent, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
-    }
 
+
+    }
 
 }

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/TestUtils.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/TestUtils.java
@@ -1,0 +1,31 @@
+package com.societegenerale.cidroid.tasks.consumer.infrastructure;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.FileCopyUtils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+
+public class TestUtils {
+
+    public static String readFileToString(String path) {
+        ResourceLoader resourceLoader = new DefaultResourceLoader();
+        Resource resource = resourceLoader.getResource(path);
+        return asString(resource);
+    }
+    private static String asString(Resource resource) {
+        try (Reader reader = new InputStreamReader(resource.getInputStream(), UTF_8)) {
+            return FileCopyUtils.copyToString(reader);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/SourceControlEventHandlerIT.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/handlers/SourceControlEventHandlerIT.java
@@ -1,9 +1,12 @@
 package com.societegenerale.cidroid.tasks.consumer.infrastructure.handlers;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventListener;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.TestConfig;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.YamlFileApplicationContextInitializer;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.AsyncConfig;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.config.InfraConfig;
 import com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.GitHubMockServer;
 import com.societegenerale.cidroid.tasks.consumer.services.model.PushEvent;
@@ -18,12 +21,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.io.IOException;
-
 import static com.societegenerale.cidroid.tasks.consumer.infrastructure.mocks.GitHubMockServer.GITHUB_MOCK_PORT;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = { InfraConfig.class, TestConfig.class },
+@ContextConfiguration(classes = { InfraConfig.class, AsyncConfig.class,TestConfig.class },
         initializers = YamlFileApplicationContextInitializer.class)
 public abstract class SourceControlEventHandlerIT {
 

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventControllerTest.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/SourceControlEventControllerTest.java
@@ -1,0 +1,77 @@
+package com.societegenerale.cidroid.tasks.consumer.infrastructure.rest;
+
+import java.io.IOException;
+
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.TestUtils;
+import com.societegenerale.cidroid.tasks.consumer.services.PullRequestEventService;
+import com.societegenerale.cidroid.tasks.consumer.services.PushEventService;
+import com.societegenerale.cidroid.tasks.consumer.services.model.PushEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(SourceControlEventController.class)
+class SourceControlEventControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private PushEventService mockPushEventService;
+
+    @MockBean
+    private PullRequestEventService mockPullRequestEventService;
+
+    @Captor
+    private ArgumentCaptor<PushEvent> sentMessage;
+
+    private String pushEventAsString;
+
+    @BeforeEach
+    void loadEventAndConfigureMock() throws IOException {
+        pushEventAsString = TestUtils.readFileToString("/gitLab/pushEventGitLab.json");
+    }
+
+    @Test
+    void forwardEventToNonDefaultBranchProcessing_whenPushOnNonDefaultBranch() throws Exception {
+
+        String pushEventOnBranchAsString = pushEventAsString.replaceAll("refs/heads/master", "refs/heads/someOtherBranch");
+
+        performPOSTandExpectSuccess(pushEventOnBranchAsString, "Push Hook");
+
+        verify(mockPushEventService, times(1)).onPushOnNonDefaultBranchEvent(sentMessage.capture());
+
+    }
+
+    @Test
+    void forwardEventToDefaultBranchProcessing_whenPushOnDefaultBranch() throws Exception {
+
+        performPOSTandExpectSuccess(pushEventAsString, "Push Hook");
+
+        verify(mockPushEventService, times(1)).onPushOnDefaultBranchEvent(sentMessage.capture());
+
+    }
+
+
+    private void performPOSTandExpectSuccess(String requestBodyContent, String headerValues) throws Exception {
+        mvc.perform(post("/cidroid-sync-webhook/gitlab")
+                .header("X-Gitlab-Event", headerValues)
+                .contentType(APPLICATION_JSON)
+                .content(requestBodyContent))
+                .andExpect(status().is2xxSuccessful());
+    }
+
+}
+

--- a/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/TestApplication.java
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/java/com/societegenerale/cidroid/tasks/consumer/infrastructure/rest/TestApplication.java
@@ -1,0 +1,24 @@
+package com.societegenerale.cidroid.tasks.consumer.infrastructure.rest;
+
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.GitLabEventDeserializer;
+import com.societegenerale.cidroid.tasks.consumer.infrastructure.SourceControlEventMapper;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@SpringBootApplication
+/**
+ * Needed for SourceControlEventControllerTest
+ */
+public class TestApplication {
+
+    @Configuration
+    class SourceControlEventControllerTestConfig {
+
+        @Bean
+        public SourceControlEventMapper gitLabEventDeserializer() {
+            return new GitLabEventDeserializer();
+        }
+
+    }
+}

--- a/ci-droid-tasks-consumer-infrastructure/src/test/resources/gitLab/mergeRequestEventGitLab.json
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/resources/gitLab/mergeRequestEventGitLab.json
@@ -1,0 +1,146 @@
+{
+  "object_kind": "merge_request",
+  "user": {
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+  },
+  "project": {
+    "id": 1,
+    "name":"Gitlab Test",
+    "description":"Aut reprehenderit ut est.",
+    "web_url":"http://example.com/gitlabhq/gitlab-test",
+    "avatar_url":null,
+    "git_ssh_url":"git@example.com:gitlabhq/gitlab-test.git",
+    "git_http_url":"http://example.com/gitlabhq/gitlab-test.git",
+    "namespace":"GitlabHQ",
+    "visibility_level":20,
+    "path_with_namespace":"gitlabhq/gitlab-test",
+    "default_branch":"master",
+    "homepage":"http://example.com/gitlabhq/gitlab-test",
+    "url":"http://example.com/gitlabhq/gitlab-test.git",
+    "ssh_url":"git@example.com:gitlabhq/gitlab-test.git",
+    "http_url":"http://example.com/gitlabhq/gitlab-test.git"
+  },
+  "repository": {
+    "name": "Gitlab Test",
+    "url": "http://example.com/gitlabhq/gitlab-test.git",
+    "description": "Aut reprehenderit ut est.",
+    "homepage": "http://example.com/gitlabhq/gitlab-test"
+  },
+  "object_attributes": {
+    "id": 99,
+    "target_branch": "master",
+    "source_branch": "ms-viewport",
+    "source_project_id": 14,
+    "author_id": 51,
+    "assignee_id": 6,
+    "title": "MS-Viewport",
+    "created_at": "2013-12-03T17:23:34Z",
+    "updated_at": "2013-12-03T17:23:34Z",
+    "milestone_id": null,
+    "state": "opened",
+    "merge_status": "unchecked",
+    "target_project_id": 14,
+    "iid": 1,
+    "description": "",
+    "source": {
+      "name":"Awesome Project",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/awesome_space/awesome_project",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
+      "namespace":"Awesome Space",
+      "visibility_level":20,
+      "path_with_namespace":"awesome_space/awesome_project",
+      "default_branch":"master",
+      "homepage":"http://example.com/awesome_space/awesome_project",
+      "url":"http://example.com/awesome_space/awesome_project.git",
+      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "http_url":"http://example.com/awesome_space/awesome_project.git"
+    },
+    "target": {
+      "name":"Awesome Project",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/awesome_space/awesome_project",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "git_http_url":"http://example.com/awesome_space/awesome_project.git",
+      "namespace":"Awesome Space",
+      "visibility_level":20,
+      "path_with_namespace":"awesome_space/awesome_project",
+      "default_branch":"master",
+      "homepage":"http://example.com/awesome_space/awesome_project",
+      "url":"http://example.com/awesome_space/awesome_project.git",
+      "ssh_url":"git@example.com:awesome_space/awesome_project.git",
+      "http_url":"http://example.com/awesome_space/awesome_project.git"
+    },
+    "last_commit": {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/awesome_space/awesome_project/commits/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@dv6700.(none)"
+      }
+    },
+    "work_in_progress": false,
+    "url": "http://example.com/diaspora/merge_requests/1",
+    "action": "open",
+    "assignee": {
+      "name": "User1",
+      "username": "user1",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+    }
+  },
+  "labels": [{
+    "id": 206,
+    "title": "API",
+    "color": "#ffffff",
+    "project_id": 14,
+    "created_at": "2013-12-03T17:15:43Z",
+    "updated_at": "2013-12-03T17:15:43Z",
+    "template": false,
+    "description": "API related issues",
+    "type": "ProjectLabel",
+    "group_id": 41
+  }],
+  "changes": {
+    "updated_by_id": {
+      "previous": null,
+      "current": 1
+    },
+    "updated_at": {
+      "previous": "2017-09-15 16:50:55 UTC",
+      "current":"2017-09-15 16:52:00 UTC"
+    },
+    "labels": {
+      "previous": [{
+        "id": 206,
+        "title": "API",
+        "color": "#ffffff",
+        "project_id": 14,
+        "created_at": "2013-12-03T17:15:43Z",
+        "updated_at": "2013-12-03T17:15:43Z",
+        "template": false,
+        "description": "API related issues",
+        "type": "ProjectLabel",
+        "group_id": 41
+      }],
+      "current": [{
+        "id": 205,
+        "title": "Platform",
+        "color": "#123123",
+        "project_id": 14,
+        "created_at": "2013-12-03T17:15:43Z",
+        "updated_at": "2013-12-03T17:15:43Z",
+        "template": false,
+        "description": "Platform related issues",
+        "type": "ProjectLabel",
+        "group_id": 41
+      }]
+    }
+  }
+}

--- a/ci-droid-tasks-consumer-infrastructure/src/test/resources/gitLab/pushEventGitLab.json
+++ b/ci-droid-tasks-consumer-infrastructure/src/test/resources/gitLab/pushEventGitLab.json
@@ -1,0 +1,70 @@
+{
+  "object_kind": "push",
+  "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
+  "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "ref": "refs/heads/master",
+  "checkout_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+  "user_id": 4,
+  "user_name": "John Smith",
+  "user_username": "jsmith",
+  "user_email": "john@example.com",
+  "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
+  "project_id": 15,
+  "project":{
+    "id": 15,
+    "name":"Diaspora",
+    "description":"",
+    "web_url":"http://example.com/mike/diaspora",
+    "avatar_url":null,
+    "git_ssh_url":"git@example.com:mike/diaspora.git",
+    "git_http_url":"http://example.com/mike/diaspora.git",
+    "namespace":"Mike",
+    "visibility_level":0,
+    "path_with_namespace":"mike/diaspora",
+    "default_branch":"master",
+    "homepage":"http://example.com/mike/diaspora",
+    "url":"git@example.com:mike/diaspora.git",
+    "ssh_url":"git@example.com:mike/diaspora.git",
+    "http_url":"http://example.com/mike/diaspora.git"
+  },
+  "repository":{
+    "name": "Diaspora",
+    "url": "git@example.com:mike/diaspora.git",
+    "description": "",
+    "homepage": "http://example.com/mike/diaspora",
+    "git_http_url":"http://example.com/mike/diaspora.git",
+    "git_ssh_url":"git@example.com:mike/diaspora.git",
+    "visibility_level":0
+  },
+  "commits": [
+    {
+      "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "message": "Update Catalan translation to e38cb41.\n\nSee https://gitlab.com/gitlab-org/gitlab for more information",
+      "title": "Update Catalan translation to e38cb41.",
+      "timestamp": "2011-12-12T14:27:31+02:00",
+      "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
+      "author": {
+        "name": "Jordi Mallach",
+        "email": "jordi@softcatala.org"
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["app/controller/application.rb"],
+      "removed": []
+    },
+    {
+      "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "message": "fixed readme",
+      "title": "fixed readme",
+      "timestamp": "2012-01-03T23:36:29+02:00",
+      "url": "http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
+      "author": {
+        "name": "GitLab dev user",
+        "email": "gitlabdev@dv6700.(none)"
+      },
+      "added": ["CHANGELOG"],
+      "modified": ["app/controller/application.rb"],
+      "removed": []
+    }
+  ],
+  "total_commits_count": 4
+}


### PR DESCRIPTION
In regular mode, CI-droid-tasks-controller receives events from an event bus (RabbitMq or Kafka, which are supported by Spring Cloud) : since processing a source control event may take some time, we usually prefer to respond immediately to source the control and acknowledge the request, then process it asynchronously. 

However, especially while prototyping, a simpler setup without a messaging bus and CI-droid may be preferable : tasks consumer could receive events directly on a REST endpoint
