### PR TITLE
upgrading arch-unit-maven-plugin to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,9 +442,8 @@
             <plugin>
                 <groupId>com.societegenerale.commons</groupId>
                 <artifactId>arch-unit-maven-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>2.6.2</version>
                 <configuration>
-                    <projectPath>${project.basedir}/target</projectPath>
                     <rules>
                         <preConfiguredRules>
                             <rule>com.societegenerale.commons.plugin.rules.NoStandardStreamRuleTest</rule>


### PR DESCRIPTION
latest version of arch-unit-maven-plugin is available, so using it