### PR TITLE
Add repository map reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/societe-generale/ci-droid-tasks-consumer.svg?branch=master)](https://travis-ci.org/societe-generale/ci-droid-tasks-consumer)
 [![Coverage Status](https://coveralls.io/repos/github/societe-generale/ci-droid-tasks-consumer/badge.svg?branch=master)](https://coveralls.io/github/societe-generale/ci-droid-tasks-consumer?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.societegenerale.ci-droid.tasks-consumer/ci-droid-tasks-consumer-services/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/com.societegenerale.ci-droid.tasks-consumer/ci-droid-tasks-consumer-services)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/societegeneralecidroidtasksconsumer/)
 
 CI-droid tasks consumer will execute the boring tasks on behalf of the dev teams.
 


### PR DESCRIPTION
## Summary

Adding repository reference map to allow developers to familiarize themselves with project structure.

## Details

Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/societegeneralecidroidtasksconsumer/). Built directly from source and updated on schedule.  

## Context

Intended to simplify developer's introduction to the project. In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.

Documentation-only change.

## Checklist:

- [x] Documentation has been updated accordingly to this PR

## Related issue : 

No corresponding issues.